### PR TITLE
Clean up the Travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,24 @@ mysql:
   username: root
   encoding: utf8
 
+install:
+  # install drush
+  - composer global require drush/drush:6.2.0
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - mkdir $HOME/.drush
+  - drush cc drush
+
+  # install additional requirements
+  - sudo apt-get update > /dev/null
+  - sudo apt-get install -y --force-yes php5-cgi php5-mysql
+
 before_script:
   # navigate out of module directory to prevent blown stack by recursive module lookup
   - cd ../..
 
-  # install drush
-  - pear channel-discover pear.drush.org
-  - pear install drush/drush-5.8.0
-  - phpenv rehash
-
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
   - mysql -e 'create database scale_addressfield'
-  - php -d sendmail_path=`which true` `pear config-get php_dir`/drush/drush.php --yes core-quick-drupal --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/scale_addressfield --enable=simpletest scale_addressfield
+  - php -d sendmail_path=`which true` `dirname $(which drush)`/drush.php --yes core-quick-drupal --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/scale_addressfield --enable=simpletest scale_addressfield
 
   # reference and enable scale_addressfield in the build site
   - ln -s $(readlink -e $(cd -)) scale_addressfield/drupal/sites/all/modules/scale_addressfield
@@ -27,9 +33,7 @@ before_script:
   - drush --yes pm-enable scale_addressfield
   - drush cc all
 
-  # start a web server on port 8080, download requirements
-  - sudo apt-get update > /dev/null
-  - sudo apt-get install -y --force-yes php5-cgi php5-mysql
+  # start a web server on port 8080
   - drush runserver 127.0.0.1:8080 &
   - sleep 4
   - drush vset --yes simpletest_verbose FALSE 


### PR DESCRIPTION
Some things to clean up:
- We should move explicitly "installation" related tasks to the "install" key.
- We should install drush via composer (I believe pear installation has been deprecated).
- We should use a more up-to-date version of drush (6.2.x).
