### PR TITLE
Create a mechanism to automatically refresh stale forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,22 @@ Scale Address Field [![Build Status](https://travis-ci.org/asmallwebfirm/scale_a
 
 This is a a utility Drupal extension that works around bugs in the 
 [Address Field][] module and Drupal core that can cause frustrating
-end-user bugs under medium-to-high user concurrency.
+end-user bugs when address fields are presented to unauthenticated users.
 
 This extension requires no configuration. Just install it and it works.
 
-This will become irrelevant when the following issues are addressed:
+### Symptoms this extension resolves or mitigates
 
-* <https://drupal.org/node/774876>
-* <https://drupal.org/node/1861608>
+* Form validation errors for unrelated fields appearing when a country is
+  selected,
+* Erroneous validation errors when a user selects a country with a known list of
+  administrative areas (potentially related to administrative area selections
+  made by unrelated users in separate threads/requests),
+* Other odd behavior related to users unknowingly affecting the state of a form
+  for other users who may also be filling out the form simultaneously,
+* Forms being unresponsive to country change (no dynamic administrative area or
+  postal code behavior) near or around cron runs / form cache clears, or in
+  cases where users have left a page open for extended periods of time.
 
 ### Installation instructions
 
@@ -20,6 +28,38 @@ using the following command:
 ```
 drush dl scale_addressfield --source=http://www.asmallwebfirm.net/drupal/release-history
 ```
+
+Enable the module like you would any other module, for example:
+
+```
+drush en scale_addressfield
+```
+
+### Optional configurations
+
+This module, by default, will attempt to fix forms that have become "stale" due
+to their rendered markup living on (in Drupal page cache, Varnish, etc) longer
+than their associated cache_form entries. The mechanism for this depends on an
+AJAX callback performing a "staleness" check at a configurable interval. There
+is no UI for this configuration, but you can use drush to change its value; by
+default, for scalability reasons, it's set to check once on initial render and
+then every 5 minutes following. You can tune this value based on your available
+resources, the rate at which this problem occurs, etc.
+
+```
+# Set the staleness check to run every 2 minutes (120 seconds).
+drush vset scale_addressfield_ping_interval 120
+```
+
+```
+# Or disable this functionality completely by setting the interval to 0.
+drush vset scale_addressfield_ping_interval 0
+```
+
+### Relevant drupal.org issues
+
+* <https://drupal.org/node/774876>
+* <https://drupal.org/node/1861608>
 
 [address field]: https://drupal.org/project/addressfield
 [drush]: https://github.com/drush-ops/drush

--- a/callbacks/healer.php
+++ b/callbacks/healer.php
@@ -18,6 +18,11 @@ define('DRUPAL_ROOT', $_SERVER['DOCUMENT_ROOT']);
 require_once DRUPAL_ROOT . '/includes/bootstrap.inc';
 require_once DRUPAL_ROOT . '/includes/common.inc';
 
+// Ensure this callback is never cached.
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
+
 // Bootstrap Drupal to the configuration stage.
 if (function_exists('drupal_bootstrap')) {
   drupal_bootstrap(DRUPAL_BOOTSTRAP_CONFIGURATION);
@@ -43,7 +48,7 @@ if (function_exists('drupal_bootstrap')) {
       $get = $_SERVER['HTTP_REFERER'] . $delimit . 'healer=' . md5(mt_rand(0, 100000));
 
       // The referer could be spoofed; let's make sure we're pointing inbound.
-      if (strpos($get, $GLOBALS['base_url']) === 0) {
+      if (strpos($get, $GLOBALS['base_root']) === 0) {
         $new_form_page = drupal_http_request($get, array(
           'headers' => array('referer' => $_SERVER['HTTP_REFERER']),
         ));

--- a/callbacks/healer.php
+++ b/callbacks/healer.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @file
+ * The Scale Addressfield module's form freshness AJAX callback.
+ *
+ * The purpose of this callback is to check if a given form still has a
+ * corresponding form cache entry. If it doesn't, it attempts to pass back the
+ * form build ID of a valid form (by rebuilding the form from the referring
+ * page and passing along its build ID).
+ *
+ * We do this here, rather than via a Drupal menu callback, for performance and
+ * scalability.
+ */
+
+// Try and load Drupal's bootstrap.inc.
+define('DRUPAL_ROOT', $_SERVER['DOCUMENT_ROOT']);
+require_once DRUPAL_ROOT . '/includes/bootstrap.inc';
+require_once DRUPAL_ROOT . '/includes/common.inc';
+
+// Bootstrap Drupal to the configuration stage.
+if (function_exists('drupal_bootstrap')) {
+  drupal_bootstrap(DRUPAL_BOOTSTRAP_CONFIGURATION);
+
+  // Only respond if valid parameters were provided.
+  if (isset($_GET['fid']) && isset($_GET['fbid']) && isset($_SERVER['HTTP_REFERER'])) {
+    // Load form.inc and database.inc to check form cache staleness.
+    require_once DRUPAL_ROOT . '/includes/form.inc';
+    require_once DRUPAL_ROOT . '/includes/database/database.inc';
+
+    // You shouldn't store your cache_form data in memory, but just in case you
+    // do, here's the logic to ensure that's accounted for.
+    require_once DRUPAL_ROOT . '/includes/cache.inc';
+    foreach (variable_get('cache_backends', array()) as $include) {
+      require_once DRUPAL_ROOT . '/' . $include;
+    }
+
+    // Check if a valid form cache entry still exists. If it does not, we'll
+    // return a new, valid form_build_id.
+    if (!cache_get('form_' . $_GET['fbid'], 'cache_form')) {
+      $response = $_GET['fbid'];
+      $delimit = strpos($_SERVER['HTTP_REFERER'], '?') !== FALSE ? '&' : '?';
+      $get = $_SERVER['HTTP_REFERER'] . $delimit . 'healer=' . md5(mt_rand(0, 100000));
+
+      // The referer could be spoofed; let's make sure we're pointing inbound.
+      if (strpos($get, $GLOBALS['base_url']) === 0) {
+        $new_form_page = drupal_http_request($get, array(
+          'headers' => array('referer' => $_SERVER['HTTP_REFERER']),
+        ));
+
+        // Ensure that our request returned a response.
+        if (isset($new_form_page->data) && !empty($new_form_page->data)) {
+          // Attempt to parse the data into a useful format.
+          $htmldom = new DOMDocument();
+          @$htmldom->loadHTML($new_form_page->data);
+
+          // Ensure successful conversion from DOMDocument to SimpleXMLElement.
+          if ($pagexml = simplexml_import_dom($htmldom)) {
+            // Attempt to pull the form_build_id from the rendered html.
+            if ($form_build = $pagexml->xpath('//form[@id="' . $_GET['fid'] . '"]//input[@name="form_build_id"]')) {
+              $response = (string) $form_build[0]->attributes()->value;
+            }
+          }
+        }
+      }
+    }
+    else {
+      // Respond with the form_build_id passed if the cache entry exists.
+      $response = $_GET['fbid'];
+    }
+
+    // Return an AJAX invoke command, including the cache form status.
+    drupal_json_output(array(
+      array(
+        'command' => 'invoke',
+        // Trigger an event named "pinged" against the given form ID, passing
+        // along a true/false on whether or not the form is fresh.
+        'method' => 'trigger',
+        'selector' => '#' . check_plain($_REQUEST['fid']),
+        'arguments' => array(
+          'pinged',
+          array(check_plain($response)),
+        ),
+      ),
+    ));
+    exit();
+  }
+}
+
+// Fallback to returning nothing.
+drupal_json_output(array());

--- a/callbacks/healer.php
+++ b/callbacks/healer.php
@@ -14,7 +14,17 @@
  */
 
 // Try and load Drupal's bootstrap.inc.
-define('DRUPAL_ROOT', $_SERVER['DOCUMENT_ROOT']);
+if (isset($_SERVER['DOCUMENT_ROOT']) && !empty($_SERVER['DOCUMENT_ROOT'])) {
+  define('DRUPAL_ROOT', $_SERVER['DOCUMENT_ROOT']);
+}
+else {
+  define('DRUPAL_ROOT', call_user_func(function($file) {
+    // If you're using this module, you know enough to know to change this
+    // to suit your particular installation. This covers the most common case.
+    $end = strpos($file, '/sites/all/modules/scale_addressfield/callbacks/healer.php');
+    return substr($file, 0, $end);
+  }, $_SERVER['SCRIPT_FILENAME']));
+}
 require_once DRUPAL_ROOT . '/includes/bootstrap.inc';
 require_once DRUPAL_ROOT . '/includes/common.inc';
 

--- a/js/healer.js
+++ b/js/healer.js
@@ -1,0 +1,70 @@
+(function($, D, w) {
+
+  // Define some globally relevant methods, namespaced on the Drupal object.
+  D.scale_addressfield = {
+
+    /**
+     * Runs through and asynchronously pings all configured forms, triggering a
+     * "pinged" event against the form. The pinged event takes a single
+     * argument, representing the form_build_id that should be associated with
+     * the form.
+     */
+    diagnose: function() {
+      $.each(D.settings.scale_addressfield.enabled_forms, function(index, value) {
+        var build_id = $('input[name="form_id"][value="' + value + '"]').siblings('input[name="form_build_id"]').val();
+        var form_selector_id = $('input[name="form_id"][value="' + value + '"]').closest('form').attr('id');
+        $.ajax(D.settings.scale_addressfield.callback + '?fid=' + form_selector_id + '&fbid=' + build_id, {
+          success: function(response, status) {
+            // Sanity check for browser support (object expected).
+            // When using iFrame uploads, responses must be returned as a string.
+            if (typeof response === 'string') {
+              response = $.parseJSON(response);
+            }
+
+            // Run through all returned commands.
+            for (var i in response) {
+              // We only care about the "invoke" command.
+              if (response.hasOwnProperty(i) && response[i]['command'] && response[i]['command'] === 'invoke') {
+                var $element = $(response[i].selector);
+                $element[response[i].method].apply($element, response[i].arguments);
+              }
+            }
+          }
+        });
+      });
+    },
+
+    /**
+     * Applies a new (theoretically valid) form_build_id over the old (probably
+     * invalid) form_build_id.
+     */
+    heal: function(form_selector_id, form_build_id) {
+      $('#' + form_selector_id + ' input[name="form_build_id"]').val(form_build_id);
+    }
+  };
+
+  /**
+   * Primary "application" logic.
+   */
+  $(document).ready(function() {
+    // Iterate through all enabled forms, attach event handlers to each form.
+    $.each(D.settings.scale_addressfield.enabled_forms, function(index, value) {
+      var form_selector_id = $('input[name="form_id"][value="' + value + '"]').closest('form').attr('id');
+      // Bind an event handler to the "pinged" event against this form.
+      $('#' + form_selector_id).bind('pinged', function(event, form_build_id) {
+        // Ensure that the form_build_id passed at least seems valid.
+        if (typeof form_build_id === 'string') {
+          // React on form staleness.
+          D.scale_addressfield.heal(form_selector_id, form_build_id);
+        }
+      });
+    });
+
+    // Invoke the ping command once on load.
+    D.scale_addressfield.diagnose();
+
+    // Set the command to be invoked once per defined interval.
+    w.setInterval(D.scale_addressfield.diagnose, D.settings.scale_addressfield.interval * 1000);
+  });
+
+})(jQuery, Drupal, window);

--- a/scale_addressfield.install
+++ b/scale_addressfield.install
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Install and update hooks for the Scale Addressfield module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function scale_addressfield_uninstall() {
+  variable_del('scale_addressfield_ping_interval');
+}

--- a/scale_addressfield.module
+++ b/scale_addressfield.module
@@ -42,6 +42,7 @@ function scale_addressfield_field_widget_form_alter(&$element, &$form_state, $co
   // We only ever want to alter the address field.
   if (isset($element['#addressfield']) && $element['#addressfield']) {
     $country = &$element['country'];
+    $module_path = drupal_get_path('module', 'scale_addressfield');
 
     // Add a validation handler to manage country selection validation errors.
     $country['#element_validate'][] = 'scale_addressfield_country_validation_errors';
@@ -62,6 +63,32 @@ function scale_addressfield_field_widget_form_alter(&$element, &$form_state, $co
       // Add another country validation handler the ensures Address Field
       // doesn't unnecessarily trigger form rebuilds.
       $country['#element_validate'][] = 'scale_addressfield_prevent_rebuild';
+
+      // Allow the form healer to be disabled when the ping interval is set to 0.
+      if ($interval = variable_get('scale_addressfield_ping_interval', 300)) {
+        // Ensure we have a JS attachment to add some custom settings.
+        if (!isset($country['#attached']['js'])) {
+          $country['#attached']['js'] = array();
+        }
+
+        // Note this form as an enabled form for the healer.
+        $country['#attached']['js'][] = array(
+          'type' => 'setting',
+          'data' => array(
+            'scale_addressfield' => array(
+              'interval' => $interval,
+              'callback' => base_path() . $module_path . '/callbacks/healer.php',
+              'enabled_forms' => array($form_state['build_info']['form_id']),
+            ),
+          ),
+        );
+
+        // Attach application logic that runs form health checks at an interval.
+        $country['#attached']['js'][] = array(
+          'type' => 'file',
+          'data' => $module_path . '/js/healer.js',
+        );
+      }
     }
   }
 }

--- a/scale_addressfield.test
+++ b/scale_addressfield.test
@@ -12,6 +12,55 @@
 abstract class ScaleAddressfieldWebTestCase extends DrupalWebTestCase {
 
   /**
+   * Machine name of the field.
+   */
+  protected $field_name = 'field_address';
+
+  /**
+   * Form element name for the country field.
+   */
+  protected $country_name = '';
+
+  /**
+   * Form element name for the administrative area field.
+   */
+  protected $state_name = '';
+
+  /**
+   * Sets up a fully configured addressfield instance.
+   */
+  protected function setUpAddressfield() {
+    // Create an Addressfield field.
+    $field = $this->createAddressfield($this->field_name);
+
+    // Attach the field to the User entity and require it on registration.
+    $field['settings'] = array('user_register_form' => 1);
+    $field['entity_type'] = 'user';
+    $field['label'] = 'Address';
+    $field['bundle'] = 'user';
+    $field['required'] = TRUE;
+    $this->createAddressfieldInstance($field);
+
+    // Set the US to the site's default country.
+    variable_set('site_default_country', 'US');
+
+    // Define some useful triggering elements and form input names.
+    $country = array(LANGUAGE_NONE, 0, 'country');
+    $this->country_name = $this->field_name . '[' . implode('][', $country) . ']';
+    $state = array(LANGUAGE_NONE, 0, 'administrative_area');
+    $this->state_name = $this->field_name . '[' . implode('][', $state) . ']';
+  }
+
+  /**
+   * Tears down the addressfield created in setUpAddressfield().
+   */
+  protected function tearDownAddressfield() {
+    // Delete the field generated in setUp().
+    $instance = field_info_instance('user', $this->field_name, 'user');
+    field_delete_instance($instance, TRUE);
+  }
+
+  /**
    * Creates a new Address Field instance.
    */
   protected function createAddressfield($name) {
@@ -98,25 +147,8 @@ class ScaleAddressfieldAJAXTestCase extends ScaleAddressfieldWebTestCase {
   function setUp() {
     parent::setUp('scale_addressfield');
 
-    // Create an Addressfield field.
-    $field = $this->createAddressfield($this->field_name);
-
-    // Attach the field to the User entity and require it on registration.
-    $field['settings'] = array('user_register_form' => 1);
-    $field['entity_type'] = 'user';
-    $field['label'] = 'Address';
-    $field['bundle'] = 'user';
-    $field['required'] = TRUE;
-    $this->createAddressfieldInstance($field);
-
-    // Set the US to the site's default country.
-    variable_set('site_default_country', 'US');
-
-    // Define some useful triggering elements and form input names.
-    $country = array(LANGUAGE_NONE, 0, 'country');
-    $this->country_name = $this->field_name . '[' . implode('][', $country) . ']';
-    $state = array(LANGUAGE_NONE, 0, 'administrative_area');
-    $this->state_name = $this->field_name . '[' . implode('][', $state) . ']';
+    // Set up a reasonable addressfield instance.
+    $this->setUpAddressfield();
 
     // Enable the page cache.
     variable_set('cache', 1);
@@ -124,9 +156,7 @@ class ScaleAddressfieldAJAXTestCase extends ScaleAddressfieldWebTestCase {
   }
 
   function tearDown() {
-    // Delete the field generated in setUp().
-    $instance = field_info_instance('user', $this->field_name, 'user');
-    field_delete_instance($instance, TRUE);
+    $this->tearDownAddressfield();
 
     // Disable the page cache.
     variable_set('cache', 0);

--- a/scale_addressfield.test
+++ b/scale_addressfield.test
@@ -259,3 +259,168 @@ class ScaleAddressfieldAdminTestCase extends ScaleAddressfieldWebTestCase {
   }
 
 }
+
+/**
+ * Test Healer functionality.
+ */
+class ScaleAddressfieldHealerTestCase extends ScaleAddressfieldWebTestCase {
+
+  /**
+   * The path to the Scale Addressfield healer callback.
+   * @var string
+   */
+  protected $healer;
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Scale Address Field Healer',
+      'description' => 'Tests Scale Address Field Healer functionality.',
+      'group' => 'Scale Address Field',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('scale_addressfield');
+
+    // Set up a reasonable addressfield instance.
+    $this->setUpAddressfield();
+
+    // Determine the path to the healer.
+    $this->healer = drupal_get_path('module', 'scale_addressfield') . '/callbacks/healer.php';
+
+    // Set a test user-agent string.
+    variable_set('scale_addressfield_healer_ua', drupal_generate_test_ua($this->databasePrefix));
+
+
+    // Enable the page cache.
+    variable_set('cache', 1);
+    variable_set('cache_lifetime', 3600);
+  }
+
+  function tearDown() {
+    $this->tearDownAddressfield();
+
+    // Disable the page cache.
+    variable_set('cache', 0);
+    variable_set('cache_lifetime', 0);
+    variable_del('scale_addressfield_healer_ua');
+    drupal_flush_all_caches();
+
+    parent::tearDown();
+  }
+
+  /**
+   * Asserts that the headers returned by the healer are valid.
+   *
+   * @param array $headers
+   *   An array of HTTP response headers, keyed by header name.
+   *
+   * @param string $x_stale
+   *   The expected value of the "x-scale-addressfield-healer" header.
+   */
+  protected function assertValidHealerHeaders($headers, $x_stale = NULL) {
+    $this->assertEqual($headers['content-type'], 'application/json', 'Correct content-type was returned');
+    $this->assertEqual($headers['expires'], 0, 'Correct "expires" header was returned.');
+    $this->assertEqual($headers['pragma'], 'no-cache', 'Correct "pragma" header was returned.');
+    $this->assertEqual($headers['cache-control'], 'no-cache, no-store, must-revalidate, max-age=0', 'Correct "cache-control" header was returned.');
+
+    if ($x_stale) {
+      $this->assertEqual($headers['x-scale-addressfield-healer'], $x_stale, format_string('The healer responded with the expected @xstale header.', array(
+        '@xstale' => $x_stale,
+      )));
+    }
+  }
+
+  /**
+   * Tests that the healer is placed and configured correctly on pages.
+   */
+  public function testHealerPlacement() {
+    // Ensure proper placement of healer JavaScript and settings / defaults.
+    $this->drupalGet('user/register');
+    $full_settings = $this->drupalGetSettings();
+    $settings = $full_settings['scale_addressfield'];
+    $this->assertEqual($settings['interval'], 300, 'Healer defaulted to an interval of 300s.');
+    $this->assertEqual($settings['callback'], '/' . $this->healer, 'Healer callback configured correctly.');
+    $this->assertTrue(array_search('user_register_form', $settings['enabled_forms']) !== FALSE, 'Form correctly configured to use the healer.');
+    $this->assertRaw('scale_addressfield/js/healer.js', 'Healer JS found on page.');
+
+    // Ensure that configuration of the interval is reflected in the settings.
+    variable_set('scale_addressfield_ping_interval', 120);
+    drupal_flush_all_caches();
+    $this->drupalGet('user/register');
+    $full_settings = $this->drupalGetSettings();
+    $settings = $full_settings['scale_addressfield'];
+    $this->assertEqual($settings['interval'], 120, 'Healer updated with interval of 120s.');
+
+    // Ensure that it's possible to turn of the healer entirely.
+    variable_set('scale_addressfield_ping_interval', 0);
+    drupal_flush_all_caches();
+    $this->drupalGet('user/register');
+    $full_settings = $this->drupalGetSettings();
+    $this->assertFalse(isset($full_settings['scale_addressfield']), 'Healer was successfully disabled.');
+    $this->assertNoRaw('scale_addressfield/js/healer.js', 'Healer JS found on page.');
+
+    // Return to defaults.
+    variable_del('scale_addressfield_ping_interval');
+  }
+
+  /**
+   * Tests that the healer callback functions as expected.
+   */
+  public function testHealerCallback() {
+    $referer = array('Referer: ' . $GLOBALS['base_root'] . '/user/register');
+    $query_defaults = array(
+      'fbid' => 'non-empty',
+      'fid' => 'user-register-form',
+    );
+
+    // Hitting the healer with no params results in an empty response.
+    $this->drupalGet($this->healer);
+    $response = drupal_json_decode($this->drupalGetContent());
+    $this->assertEqual($response, array(), 'Request to the healer with no params resulted in an empty response.');
+    $this->assertValidHealerHeaders($this->drupalGetHeaders());
+
+    // Hitting the healer with all required (but meaningless) params results in
+    // the expected "trigger" response AJAX response.
+    $this->drupalGet($this->healer, array('query' => $query_defaults), $referer);
+    $response = drupal_json_decode($this->drupalGetContent());
+    $this->assertValidHealerHeaders($this->drupalGetHeaders(), 'Stale');
+    $this->assertEqual($response[0]['method'], 'trigger', 'The healer returned a "trigger" method.');
+    $this->assertEqual($response[0]['command'], 'invoke', 'The healer returned an "invoke" command.');
+    $this->assertEqual($response[0]['selector'], '#' . $query_defaults['fid'], 'The healer responded with the correct selector.');
+    $this->assertEqual($response[0]['arguments'][0], 'pinged', 'The healer responded with the correct event name.');
+
+    // Hitting the healer with a legitimate fbid results in it responding back
+    // with the exact same fbid and a positive header.
+    $query_defaults['fbid'] = '12345abcde';
+    cache_set('form_' . $query_defaults['fbid'], array('data'), 'cache_form');
+    $this->drupalGet($this->healer, array('query' => $query_defaults), $referer);
+    $response = drupal_json_decode($this->drupalGetContent());
+    $this->assertValidHealerHeaders($this->drupalGetHeaders(), 'Fresh');
+    $this->assertEqual($response[0]['arguments'][1][0], $query_defaults['fbid'], 'The healer responded with the correct form build ID.');
+
+    // Hitting the healer with the same fbid, but after expiry results in it
+    // responding back with a negative header and a new fbid.
+    cache_clear_all('form_' . $query_defaults['fbid'], 'cache_form');
+    $this->drupalGet($this->healer, array('query' => $query_defaults), $referer);
+    $response = drupal_json_decode($this->drupalGetContent());
+    $this->assertValidHealerHeaders($this->drupalGetHeaders(), 'Stale');
+    $fresh_fbid = $response[0]['arguments'][1][0];
+    $this->assertNotEqual($fresh_fbid, $query_defaults['fbid'], 'The healer responded with a new form build ID.');
+
+    // Hitting the healer with the same, previous fbid results in it responding
+    // back with yet another fbid.
+    $this->drupalGet($this->healer, array('query' => $query_defaults), $referer);
+    $response = drupal_json_decode($this->drupalGetContent());
+    $this->assertValidHealerHeaders($this->drupalGetHeaders(), 'Stale');
+    $this->assertNotEqual($response[0]['arguments'][1][0], $query_defaults['fbid'], 'The healer responded with a new form build ID.');
+    $this->assertNotEqual($response[0]['arguments'][1][0], $fresh_fbid, 'The fbid provided was not previously returned.');
+
+    // Hitting the healer with the generated fbid results in a "fresh" response.
+    $query_defaults['fbid'] = $fresh_fbid;
+    $this->drupalGet($this->healer, array('query' => $query_defaults), $referer);
+    $response = drupal_json_decode($this->drupalGetContent());
+    $this->assertValidHealerHeaders($this->drupalGetHeaders(), 'Fresh');
+    $this->assertEqual($response[0]['arguments'][1][0], $query_defaults['fbid'], 'The healer responded with the correct form build ID.');
+  }
+}


### PR DESCRIPTION
All of the work gone into this module is great, but it doesn't prevent edge cases where forms may become stale despite a page's cache living on (either in Drupal's page cache, or in an external cache).

The end-result is a period during which AJAX requests triggered on the country field fail; to the end-user, this manifests as perceived cultural ineptitude (e.g. "I selected country Y, which doesn't have country X's states).

We should be able to detect when this state has happened (before a user triggers an AJAX request), and correct it if it happens, without inconveniencing the user in any way.
