### PR TITLE
Fix for test build/fail regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ mysql:
   encoding: utf8
 
 install:
-  # install drush
+  # install drush 5.x (because 6.x's test-run doesn't exit with proper status code).
   - pear channel-discover pear.drush.org
   - pear install drush/drush-5.10.0.0
   - phpenv rehash
@@ -37,5 +37,4 @@ before_script:
   - sleep 4
   - drush vset --yes simpletest_verbose FALSE 
 
-script:
-  - drush test-run 'Scale Address Field' --uri=http://127.0.0.1:8080
+script: drush test-run 'Scale Address Field' --uri=http://127.0.0.1:8080

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,9 @@ mysql:
 
 install:
   # install drush
-  - composer global require drush/drush:6.2.0
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - mkdir $HOME/.drush
-  - drush cc drush
+  - pear channel-discover pear.drush.org
+  - pear install drush/drush-5.10.0.0
+  - phpenv rehash
 
   # install additional requirements
   - sudo apt-get update > /dev/null
@@ -25,7 +24,7 @@ before_script:
 
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
   - mysql -e 'create database scale_addressfield'
-  - php -d sendmail_path=`which true` `dirname $(which drush)`/drush.php --yes core-quick-drupal --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/scale_addressfield --enable=simpletest scale_addressfield
+  - php -d sendmail_path=`which true` `pear config-get php_dir`/drush/drush.php --yes core-quick-drupal --profile=testing --no-server --db-url=mysql://root:@127.0.0.1/scale_addressfield --enable=simpletest scale_addressfield
 
   # reference and enable scale_addressfield in the build site
   - ln -s $(readlink -e $(cd -)) scale_addressfield/drupal/sites/all/modules/scale_addressfield
@@ -38,4 +37,5 @@ before_script:
   - sleep 4
   - drush vset --yes simpletest_verbose FALSE 
 
-script: drush test-run 'Scale Address Field' --uri=http://127.0.0.1:8080
+script:
+  - drush test-run 'Scale Address Field' --uri=http://127.0.0.1:8080

--- a/callbacks/healer.php
+++ b/callbacks/healer.php
@@ -32,7 +32,6 @@ require_once DRUPAL_ROOT . '/includes/common.inc';
 header('Cache-Control: no-cache, no-store, must-revalidate, max-age=0');
 header('Pragma: no-cache');
 header('Expires: 0');
-die();
 
 // Bootstrap Drupal to the configuration stage.
 if (function_exists('drupal_bootstrap')) {

--- a/callbacks/healer.php
+++ b/callbacks/healer.php
@@ -32,6 +32,7 @@ require_once DRUPAL_ROOT . '/includes/common.inc';
 header('Cache-Control: no-cache, no-store, must-revalidate, max-age=0');
 header('Pragma: no-cache');
 header('Expires: 0');
+die();
 
 // Bootstrap Drupal to the configuration stage.
 if (function_exists('drupal_bootstrap')) {


### PR DESCRIPTION
Turns out the test improvements pull request (#6) caused a regression where test failures didn't signal build failures.  This is because drush 6.x doesn't return the correct exit code.  7.x does, but it's not stable enough yet.  Unfortunately, drush 5.x isn't available via Composer/Packagist, so we have to revert to the less reliable pear install method.
