### PR TITLE
Fix missing localityname (city) field in some situations

### DIFF
--- a/scale_addressfield.address.inc
+++ b/scale_addressfield.address.inc
@@ -120,7 +120,15 @@ function scale_addressfield_override_format(&$format, $address, $context = array
               ),
               'type' => 'setting',
             );
-            $format[$container][$name]['#attributes']['class'][] = $xnal_field;
+            // Special case for "localityname" because Address Field provides
+            // "locality" as a class name by default. So, overwrite it entirely.
+            if ($xnal_field == 'localityname') {
+              $format[$container][$name]['#attributes']['class'] = array($xnal_field);
+            }
+            else {
+              // Otherwise, just append our class.
+              $format[$container][$name]['#attributes']['class'][] = $xnal_field;
+            }
           }
         }
       }

--- a/scale_addressfield.test
+++ b/scale_addressfield.test
@@ -146,6 +146,8 @@ abstract class ScaleAddressfieldWebTestCase extends DrupalWebTestCase {
 
     if ($elements) {
       foreach ($elements as $element) {
+        // Add extra padding (in case the class comes first or last).
+        $element['class'] = ' ' . $element['class'] . ' ';
         if (isset($element['class']) && strpos($element['class'], $class) !== FALSE) {
           $has_class = TRUE;
         }
@@ -252,6 +254,10 @@ class ScaleAddressfieldFormRenderTestCase extends ScaleAddressfieldWebTestCase {
         )));
       }
     }
+
+    // Ensure the localityname field does not have a "locality" class.
+    $field = $this->xpath($this->constructFieldXpath('name', $this->fields['localityname']));
+    $this->assertTrue(strpos('locality ', $field[0]['class']) === FALSE, 'Locality class not found on localityname element.');
 
     // Ensure that the administrative area field is rendered as a textfield.
     $this->assertFieldByXpath($this->buildXPathQuery('//input[@name=:name]', array(


### PR DESCRIPTION
Looks like there's a conflict between the locality and localityname fields, in terms of how we assign classes (because Address Field uses non-standard names for xNAL fields).

Here's a simple fix to remove the conflict.
