### PR TITLE
Updating to the latest addressfield.json

### DIFF
--- a/config/address-formats.json
+++ b/config/address-formats.json
@@ -2936,7 +2936,7 @@
         "administrativearea" : {
           "label" : "Region",
           "options" : {
-            "AUK" : "Aukland",
+            "AUK" : "Auckland",
             "BOP" : "Bay of Plenty",
             "CAN" : "Canterbury",
             "HKB" : "Hawke's Bay",


### PR DESCRIPTION
Fixes a minor typo in the list of NZ regions.
