### PR TITLE
Localize/modify country based on config.

### DIFF
--- a/scale_addressfield.address.inc
+++ b/scale_addressfield.address.inc
@@ -44,6 +44,9 @@ function scale_addressfield_override_format(&$format, $address, $context = array
 
     // Update the list of countries based on our configuration.
     $format['country']['#options'] = array_intersect_key($format['country']['#options'], $config['options']);
+    foreach ($format['country']['#options'] as $code => $label) {
+      $format['country']['#options'][$code] = $config['options'][$code]['label'];
+    }
     $missing_countries = array_diff_key($config['options'], $format['country']['#options']);
     foreach ($missing_countries as $code => $definition) {
       $format['country']['#options'][$code] = $definition['label'];


### PR DESCRIPTION
Currently, country labels are pulled from a random combination of default Drupal country list + JSON config (only for those defined in the config, but missing in the default).

We should pull the country labels over from the config; for many, it will have no effect, but for those with localized country labels, this will fix things.
